### PR TITLE
Remove trailing comma so that JSON is valid.

### DIFF
--- a/crunch/packer.cpp
+++ b/crunch/packer.cpp
@@ -184,7 +184,10 @@ void Packer::SaveJson(const string& name, ofstream& json, bool trim, bool rotate
         }
         if (rotate)
             json << ", \"r\":" << (points[i].rot ? "true" : "false");
-        json << " }," << endl;
+        json << " }";
+        if(i != bitmaps.size() -1)
+            json << ",";
+        json << endl;
     }
     json << "\t\t\t]" << endl;
 }


### PR DESCRIPTION
The JSON output was slightly invalid, which causes the JSON parser in haxe to throw a runtime error. This fixes it so that the last image doesn't have a trailing comma.

Before:
```
{
	"textures":[
		{
			"name":"atlas",
			"images":[
				{ "n":"some-image", "x":0, "y":0, "w":212, "h":216 },
				{ "n":"some-other-image", "x":213, "y":0, "w":174, "h":156 },
				{ "n":"the-last-image", "x":213, "y":157, "w":155, "h":139 },
			]
		}
	]
}
```

After:
```
{
	"textures":[
		{
			"name":"atlas",
			"images":[
				{ "n":"some-image", "x":0, "y":0, "w":212, "h":216 },
				{ "n":"some-other-image", "x":213, "y":0, "w":174, "h":156 },
				{ "n":"the-last-image", "x":213, "y":157, "w":155, "h":139 }
			]
		}
	]
}
```