### PR TITLE
Add support for TexturePacker-style atlases in export

### DIFF
--- a/crunch/main.cpp
+++ b/crunch/main.cpp
@@ -82,6 +82,7 @@ static int optPadding;
 static bool optXml;
 static bool optBinary;
 static bool optJson;
+static bool optTexturePacker;
 static bool optPremultiply;
 static bool optTrim;
 static bool optVerbose;
@@ -231,6 +232,7 @@ int main(int argc, const char* argv[])
     optXml = false;
     optBinary = false;
     optJson = false;
+    optTexturePacker = false;
     optPremultiply = false;
     optTrim = false;
     optVerbose = false;
@@ -247,6 +249,8 @@ int main(int argc, const char* argv[])
             optBinary = true;
         else if (arg == "-j" || arg == "--json")
             optJson = true;
+        else if (arg == "--texturepacker")
+            optTexturePacker = true;
         else if (arg == "-p" || arg == "--premultiply")
             optPremultiply = true;
         else if (arg == "-t" || arg == "--trim")
@@ -316,6 +320,7 @@ int main(int argc, const char* argv[])
         cout << "\t--xml: " << (optXml ? "true" : "false") << endl;
         cout << "\t--binary: " << (optBinary ? "true" : "false") << endl;
         cout << "\t--json: " << (optJson ? "true" : "false") << endl;
+        cout << "\t--texturepacker" << (optTexturePacker ? "true" : "false") << endl;
         cout << "\t--premultiply: " << (optPremultiply ? "true" : "false") << endl;
         cout << "\t--trim: " << (optTrim ? "true" : "false") << endl;
         cout << "\t--verbose: " << (optVerbose ? "true" : "false") << endl;
@@ -422,6 +427,19 @@ int main(int argc, const char* argv[])
         }
         json << "\t]" << endl;
         json << '}';
+    }
+    
+    
+    //Save the TexturePacker-style atlas
+    if (optTexturePacker)
+    {
+        if (optVerbose)
+            cout << "writing texturepacker atlas: " << outputDir << name << ".atlas" << endl;
+        
+        for (size_t i = 0; i < packers.size(); ++i)
+        {
+            packers[i]->SaveTexturePacker(name + to_string(i), outputDir, optTrim, optRotate);
+        }
     }
     
     //Save the new hash

--- a/crunch/packer.cpp
+++ b/crunch/packer.cpp
@@ -191,3 +191,27 @@ void Packer::SaveJson(const string& name, ofstream& json, bool trim, bool rotate
     }
     json << "\t\t\t]" << endl;
 }
+
+void Packer::SaveTexturePacker(const string &name, const string &outputDir, bool trim, bool rotate)
+{
+    ofstream atlas(outputDir + name + ".atlas");
+    
+    atlas << endl << name << endl;
+    atlas << "size: " << to_string(width) << "," << to_string(height) << endl;
+    atlas << "format: " << "RGBA8888" << endl;
+    atlas << "filter: Linear,Linear" << endl;
+    atlas << "repeat: none" << endl;
+    
+    const string tab = "  ";
+    
+    for(size_t i = 0, j = bitmaps.size(); i < j; ++i)
+    {
+        atlas << outputDir + bitmaps[i]->name << endl;
+        atlas << tab << "rotate: " << (points[i].rot ? "true" : "false") << endl;
+        atlas << tab << "xy: " << points[i].x << ", " << points[i].y << endl;
+        atlas << tab << "size: " << bitmaps[i]->width << ", " << bitmaps[i]->height << endl;
+        atlas << tab << "orig: " << bitmaps[i]->width << ", " << bitmaps[i]->height << endl;
+        atlas << tab << "offset: 0, 0" << endl;
+        atlas << tab << "index: -1" << endl;
+    }
+}

--- a/crunch/packer.hpp
+++ b/crunch/packer.hpp
@@ -58,6 +58,7 @@ struct Packer
     void SaveXml(const string& name, ofstream& xml, bool trim, bool rotate);
     void SaveBin(const string& name, ofstream& bin, bool trim, bool rotate);
     void SaveJson(const string& name, ofstream& json, bool trim, bool rotate);
+    void SaveTexturePacker(const string& name, const string& atlas, bool trim, bool rotate);
 };
 
 #endif


### PR DESCRIPTION
Adds an export option for .atlas files that resemble .tps exports. Doesn't add all the features TexturePacker includes, just a matching export for projects that require it!