### PR TITLE
INPUT DIRECTORY and OUTPUT PREFIX are backward in the no-arguments error

### DIFF
--- a/crunch/main.cpp
+++ b/crunch/main.cpp
@@ -207,7 +207,7 @@ int main(int argc, const char* argv[])
     
     if (argc < 3)
     {
-        cerr << "invalid input, expected: \"crunch [INPUT DIRECTORY] [OUTPUT PREFIX] [OPTIONS...]\"" << endl;
+        cerr << "invalid input, expected: \"crunch [OUTPUT DIRECTORY] [INPUTS] [OPTIONS...]\"" << endl;
         return EXIT_FAILURE;
     }
     


### PR DESCRIPTION
Very minor change. This makes the message printed when you run ./crunch align with the README.